### PR TITLE
updated binning function

### DIFF
--- a/scripts/categorize_by_function.py
+++ b/scripts/categorize_by_function.py
@@ -53,7 +53,7 @@ def main():
                                  opts.ignore)
     table = parse_biom_table(open(opts.input_fp))
     result = table.collapseObservationsByMetadata(collapse_f, one_to_many=True, 
-                                                  norm=False)
+                          norm=False,one_to_many_md_key=opts.metadata_category)
     
     f = open(opts.output_fp,'w')
     f.write(result.getBiomFormatJsonString('picrust %s - categorize_by_function'\


### PR DESCRIPTION
fixes #80 but do not merge yet incase further updates are necessary to resolve how the KEGG Pathways are stored.

Note, as a result of biom-format/biom-format#101, the collapsed pathway is now in the metadata as "Path". This is parameterized, however, so the resulting metadata key can be different if desired and specified either by the user or by the `categorize_by_function.py` driver script.
