### PR TITLE
Addresses Issue #158. Allow pathway filtering in metagenome_contributions.py

### DIFF
--- a/picrust/metagenome_contributions.py
+++ b/picrust/metagenome_contributions.py
@@ -15,12 +15,70 @@ from numpy import dot, array, around
 from biom.table import table_factory
 from picrust.predict_metagenomes import get_overlapping_ids,extract_otu_and_genome_data
 
-def partition_metagenome_contributions(otu_table,genome_table, limit_to_functions=[], remove_zero_rows=True,verbose=True):
+
+def make_pathway_filter_fn(ok_values,metadata_key='KEGG_Pathways',seach_only_pathway_level=None):
+    """return a filter function that filters observations by pathway
+
+    ok_values -- valid pathway category names (e.g. ['Metabolism'] in the KEGG pathway categories.
+      By default, if the pathway is present at any level, keep the observation.  
+      Matches can be limited to a specific level of the pathway 
+      using search_only_pathway_level
+
+    metadata_key -- the metadata key to filter observations against. 
+      e.g. 'KEGG_Pathways','COG_Category'
+
+    search_only_pathway_level -- only check a given level of the pathway hierarchy
+   
+    NOTES:
+    metadata for metadata_key is expected to be a list of annotations, 
+    with each annotation a list of pathway levels
+    
+    COG Example:
+    "metadata": {"COG_Description": "Uncharacterized conserved protein",\
+                 "COG_Category": [["POORLY CHARACTERIZED", "[S] Function unknown"]]}}
+    
+    KEGG Example:
+    "metadata": {"KEGG_Description": ["cathepsin L [EC:3.4.22.15]"],\
+      "KEGG_Pathways": [["Human Diseases", "Immune System Diseases", "Rheumatoid arthritis"], 
+      ["Metabolism", "Enzyme Families", "Peptidases"], 
+      ["Organismal Systems", "Immune System", "Antigen processing and presentation"], 
+      ["Cellular Processes", "Transport and Catabolism", "Phagosome"], 
+      ["Genetic Information Processing", "Folding, Sorting and Degradation", "Chaperones and folding catalysts"], 
+      ["Cellular Processes", "Transport and Catabolism", "Lysosome"]]}
+    """
+
+    def filter_observation_by_pathway(obs_value,obs_id,obs_metadata):
+        function_md = obs_metadata[metadata_key]
+        
+        #Note that many pathway annotations per observation are allowed
+        for annotation in function_md:
+            for level,function in enumerate(function_md):
+                #Skip this level if it isn't the desired level
+                if pathway_level is not None:
+                    if level != pathway_level:
+                        continue
+                
+                #If we're on the right level,
+                #check if the annotation matches
+                if function in ok_values:
+                    return True
+
+        #If we've scanned all values and no match is found,
+        #return False to discard the observation
+        return False
+
+def partition_metagenome_contributions(otu_table,genome_table, limit_to_functions=[],
+        limit_to_function_categories=[], metadata_key = None,remove_zero_rows=True,verbose=True):
     """Return a list of the contribution of each organism to each function, per sample
     (rewritten version using numpy)
     otu_table -- the BIOM Table object for the OTU table
     genome_table -- the BIOM Table object for the predicted genomes
-    limit_to_functions -- a list of function ids to include.  If empty, include all function ids
+    limit_to_functions -- a list of function ids to include.  
+      If empty, include all function ids
+    
+    limit_by_function_categories -- if provided limit by functional category.  
+      For example, this can be used to limit output by KEGG functional categories
+    
     Output table as a list of lists with header
     Function\tOrganism\tSample\tCounts\tpercent_of_sample
     """
@@ -31,7 +89,6 @@ def partition_metagenome_contributions(otu_table,genome_table, limit_to_function
         ok_ids = frozenset(map(str,limit_to_functions))
         
         filter_by_set = lambda vals,gene_id,metadata: str(gene_id) in ok_ids
-        #filter_by_set = lambda vals,gene_id,metadata: gene_id in ok_ids
         
         #if verbose:
             #print dir(genome_table)

--- a/scripts/metagenome_contributions.py
+++ b/scripts/metagenome_contributions.py
@@ -51,6 +51,7 @@ script_info['optional_options'] = [\
     make_option('-c','--input_count_table',default=None,type="existing_filepath",help='Precalculated function predictions on per otu basis in biom format (can be gzipped). Note: using this option overrides --type_of_prediction and --gg_version. [default: %default]'),
  make_option('--suppress_subset_loading',default=False,action="store_true",help='Normally, only counts for OTUs present in the sample are loaded.  If this flag is passed, the full biom table is loaded.  This makes no difference for the analysis, but may result in faster load times (at the cost of more memory usage)'),    
     make_option('--load_precalc_file_in_biom',default=False,action="store_true",help='Instead of loading the precalculated file in tab-delimited format (with otu ids as row ids and traits as columns) load the data in biom format (with otu as SampleIds and traits as ObservationIds) [default: %default]'),
+    make_option('-f','--limit_to_functional_categories',default=False,action="store",type='string',help='If provided only output prediction for functions that match the specified functional category. Multiple categories can be passed as a comma-separated list [default: %default]'),
         make_option('-l','--limit_to_function',default=None,help='If provided, only output predictions for the specified function ids.  Multiple function ids can be passed using comma delimiters.')
 ]
 script_info['version'] = __version__
@@ -114,8 +115,15 @@ def main():
             genome_table = parse_biom_table(genome_table_fh.read())
     else:
         genome_table = convert_precalc_to_biom(genome_table_fh,ids_to_load)
+    ok_function_categories = None
     
-    partitioned_metagenomes = partition_metagenome_contributions(otu_table,genome_table,limit_to_functions=limit_to_functions)
+    if opts.limit_to_functional_categories:
+        ok_functional_categories = opts.limit_to_functional_categories.split(",")
+        if opts.verbose:
+            print "Limiting to functional categories: %s" %(str(ok_functional_categories))
+    partitioned_metagenomes = partition_metagenome_contributions(otu_table,genome_table,limit_to_functions=limit_to_functions,\
+      limit_to_functional_categories = ok_functional_categories)
+
     output_text = "\n".join(["\t".join(map(str,i)) for i in partitioned_metagenomes])
     if opts.verbose:
         print "Writing results to output file: ",opts.output_fp

--- a/scripts/metagenome_contributions.py
+++ b/scripts/metagenome_contributions.py
@@ -115,7 +115,7 @@ def main():
             genome_table = parse_biom_table(genome_table_fh.read())
     else:
         genome_table = convert_precalc_to_biom(genome_table_fh,ids_to_load)
-    ok_function_categories = None
+    ok_functional_categories = None
     
     if opts.limit_to_functional_categories:
         ok_functional_categories = opts.limit_to_functional_categories.split(",")

--- a/tests/test_metagenome_contributions.py
+++ b/tests/test_metagenome_contributions.py
@@ -15,7 +15,8 @@ __status__ = "Development"
 from cogent.util.unit_test import TestCase, main
 from biom.parse import parse_biom_table_str
 from biom.table import DenseTable
-from picrust.metagenome_contributions import partition_metagenome_contributions
+from picrust.metagenome_contributions import partition_metagenome_contributions,\
+  make_pathway_filter_fn
 from picrust.predict_metagenomes import predict_metagenomes,\
   calc_nsti,get_overlapping_ids, extract_otu_and_genome_data
 
@@ -27,18 +28,31 @@ class PartitionMetagenomeTests(TestCase):
         self.otu_table_with_taxonomy = parse_biom_table_str(otu_table_with_taxonomy)
         self.genome_table1 = parse_biom_table_str(genome_table1)
         self.genome_table2 = parse_biom_table_str(genome_table2)
-        self.predicted_metagenome_table1 = parse_biom_table_str(predicted_metagenome_table1)
+        self.predicted_metagenome_table1 =\
+          parse_biom_table_str(predicted_metagenome_table1)
         self.predicted_gene_partition_table = predicted_gene_partition_table
-        self.predicted_gene_partition_table_with_taxonomy = predicted_gene_partition_table_with_taxonomy
+        self.predicted_gene_partition_table_with_taxonomy =\
+          predicted_gene_partition_table_with_taxonomy
+
+        #Examples of BIOM format value,id,metadata tuples
+        #as returned when iterating over a table
+        #metadata are defined at the bottom of this file.
+        self.metadata_example = [(700.0,"Gene1",example_metadata1),\
+          (250.0,"Gene2",example_metadata2),(0.0,"Gene3",example_metadata3)]
 
 
     def test_partition_metagenome_contributions_with_taxonomy(self):
-        obs = partition_metagenome_contributions(self.otu_table_with_taxonomy,self.genome_table1)
-        
+        """partition_metagenome_contributions is OK with BIOM tables containing  taxonomy"""
+        obs = partition_metagenome_contributions(\
+          self.otu_table_with_taxonomy,self.genome_table1)
         obs_text = "\n".join(["\t".join(map(str,i)) for i in obs])
-        exp_text_list = [map(str,r.split()) for r in self.predicted_gene_partition_table_with_taxonomy.split('\n')]
         
-        #BIOM adds spaces to metadata fields (not sure why), so add them here just for the taxonomy fields
+        exp_table = self.predicted_gene_partition_table_with_taxonomy
+        exp_text_list =\
+          [map(str,r.split()) for r in exp_table.split('\n')]
+        
+        #BIOM adds spaces to metadata fields (not sure why), 
+        #so add them here just for the taxonomy fields
         for row in exp_text_list[1:]:
             row[9]=' '+row[9]
             row[10]=' '+row[10]
@@ -51,9 +65,72 @@ class PartitionMetagenomeTests(TestCase):
 
         self.assertEqual(obs_text,exp_text)
        
+    def test_make_pathway_filter_fn_KEGG(self):
+        """make_pathway_filter_function functions with valid KEGG data"""
+        filter_fn = make_pathway_filter_fn(["Phagosome"],\
+         metadata_key = 'KEGG_Pathways')
+        
+        test_md = self.metadata_example 
+        exp_result = [True,True,False] 
+        obs_result = [filter_fn(*md) for md in test_md]
+        self.assertEqual(obs_result,exp_result)
+
+    def test_make_pathway_filter_fn_by_level(self):
+        """make_pathway_filter_function functions specifying KEGG pathway cat level"""
+        
+        test_md = self.metadata_example 
+        #Example 1 has a top-level 'Unclassifed' annotation
+        #Example 3 has a bottom-level 'Unclassified' annotation
+       
+        #Test 1.  When not specifying level, all levels should be
+        #tested and examples 1 & 3 should both return True
+
+        filter_fn = make_pathway_filter_fn(["Unclassified"],\
+         metadata_key = 'KEGG_Pathways')
+        exp_result = [True,False,True] 
+        obs_result = [filter_fn(*md) for md in test_md]
+        self.assertEqual(obs_result,exp_result)
+
+        #Test 2. When specifying level 1, only Example 1 is true
+        filter_fn = make_pathway_filter_fn(["Unclassified"],\
+         metadata_key = 'KEGG_Pathways',search_only_pathway_level = 1)
+        exp_result = [True,False,False] 
+        obs_result = [filter_fn(*md) for md in test_md]
+        self.assertEqual(obs_result,exp_result)
+
+
+        #Test 3. When specifying level 3, only Example 3 is true
+        filter_fn = make_pathway_filter_fn(["Unclassified"],\
+         metadata_key = 'KEGG_Pathways',search_only_pathway_level = 3)
+        exp_result = [False,False,True] 
+        obs_result = [filter_fn(*md) for md in test_md]
+        self.assertEqual(obs_result,exp_result)
+
+    def test_make_pathway_filter_fn_raises_on_bad_input(self):
+        """make_pathway_filter_fn raises on invalid metadata level"""
+        #No error on specifying level 1
+        filter_fn = make_pathway_filter_fn(["Unclassified"],\
+            metadata_key = 'KEGG_Pathways',search_only_pathway_level = 1)
+        with self.assertRaises(ValueError):
+            #Specifying level 0 should raise an informative error
+            filter_fn = make_pathway_filter_fn(["Unclassified"],\
+              metadata_key = 'KEGG_Pathways',search_only_pathway_level = 0)
+    
+    def test_pathway_filter_fn_raises_on_bad_md_key(self):
+        """make_pathway_filter_fn child fn raises informatively on invalid metadata"""
+        
+        test_md = self.metadata_example 
+        
+        #Assume user misspells 'KEGG_Pathways'
+        filter_fn = make_pathway_filter_fn(["Unclassified"],\
+          metadata_key = 'KEGG_Pathwayssssssss')
+        
+        with self.assertRaises(ValueError):
+            obs_result = [filter_fn(*md) for md in test_md]
+
 
     def test_partition_metagenome_contributions(self):
-        """partition_metagenome_contributions functions as expected with valid input"""
+        """partition_metagenome_contributions functions with valid input"""
         #For reference, the OTU table should look like this:
         ##OTU ID Sample1 Sample2 Sample3 Sample4
         #GG_OTU_1    1.0 2.0 3.0 5.0
@@ -75,28 +152,42 @@ class PartitionMetagenomeTests(TestCase):
         #First, sanity checks
         
         #We expect to see the contributions broken down by OTU 
-        metagenome_table = predict_metagenomes(self.otu_table1,self.genome_table1)
-        obs = partition_metagenome_contributions(self.otu_table1,self.genome_table1)
+        metagenome_table =\
+          predict_metagenomes(self.otu_table1,self.genome_table1)
+        obs =\
+          partition_metagenome_contributions(self.otu_table1,\
+            self.genome_table1)
         
         obs_text = "\n".join(["\t".join(map(str,i)) for i in obs])
-        exp_text = "\n".join(["\t".join(map(str,r.split())) for r in self.predicted_gene_partition_table.split('\n')])
+        exp_text = "\n".join(["\t".join(map(str,r.split())) for r in \
+          self.predicted_gene_partition_table.split('\n')])
 
-        #Test that the percent of all samples is always smaller than the percent of the current sample
+        #Test that the percent of all samples is always smaller than
+        #the percent of the current sample
         for l in obs[1:]:
             self.assertTrue(l[-1]<=l[-2])
         
-        #Test that the summed contributions equal the metagenome table value
-        sum_f1_sample1 = sum([i[5] for i in obs[1:] if (i[0]=="f1" and i[1]=="Sample1")])
+        #Test that the summed contributions equal 
+        #the metagenome table value
+
+        sum_f1_sample1 = sum(\
+          [i[5] for i in obs[1:] if (i[0]=="f1" and i[1]=="Sample1")])
         self.assertFloatEqual(sum_f1_sample1,16.0)
-        sum_f2_sample1 = sum([i[5] for i in obs[1:] if (i[0]=="f2" and i[1]=="Sample1")])
+        
+        sum_f2_sample1 = sum(\
+          [i[5] for i in obs[1:] if (i[0]=="f2" and i[1]=="Sample1")])
         self.assertFloatEqual(sum_f2_sample1,0.0)
-        sum_f3_sample1 = sum([i[5] for i in obs[1:] if (i[0]=="f3" and i[1]=="Sample1")])
+        
+        sum_f3_sample1 = sum(\
+          [i[5] for i in obs[1:] if (i[0]=="f3" and i[1]=="Sample1")])
         self.assertFloatEqual(sum_f3_sample1,5.0)
 
         for l in obs[1:]:
-            gene,sample,OTU,gene_count_per_genome,otu_abundance_in_sample,count,percent,percent_all = l    
+            gene,sample,OTU,gene_count_per_genome,\
+              otu_abundance_in_sample,count,percent,percent_all = l    
             #Test that genomes without genes don't contribute
-            #Only GG_OTU_3 has f2, so for all others the gene contribution should be 0,0
+            #Only GG_OTU_3 has f2, so for all others the gene
+            #contribution should be 0,0
             if gene == "f2" and OTU != "GG_OTU_3":
                 self.assertFloatEqual(count,0.0)
                 self.assertFloatEqual(percent,0.0)
@@ -113,7 +204,8 @@ class PartitionMetagenomeTests(TestCase):
                 self.assertFloatEqual(percent,0.0)
                 self.assertFloatEqual(percent_all,0.0)
         
-        #Having validated that this looks OK, just compare to hand-checked result
+        #Having validated that this looks OK, just compare to 
+        #hand-checked result
         self.assertEqual(obs_text,exp_text)
        
 otu_table1 = """{"rows": [{"id": "GG_OTU_1", "metadata": null}, {"id": "GG_OTU_2", "metadata": null}, {"id": "GG_OTU_3", "metadata": null}], "format": "Biological Observation Matrix v0.9", "data": [[0, 0, 1.0], [0, 1, 2.0], [0, 2, 3.0], [0, 3, 5.0], [1, 0, 5.0], [1, 1, 1.0], [1, 3, 2.0], [2, 2, 1.0], [2, 3, 4.0]], "columns": [{"id": "Sample1", "metadata": null}, {"id": "Sample2", "metadata": null}, {"id": "Sample3", "metadata": null}, {"id": "Sample4", "metadata": null}], "generated_by": "QIIME 1.4.0-dev, svn revision 2753", "matrix_type": "sparse", "shape": [3, 4], "format_url": "http://www.qiime.org/svn_documentation/documentation/biom_format.html", "date": "2012-02-22T20:50:05.024661", "type": "OTU table", "id": null, "matrix_element_type": "float"}"""
@@ -159,6 +251,39 @@ f2  Sample4 GG_OTU_3    1.0 4.0 4.0 1.0 0.8    k__3      p__     c__     o__    
 f3  Sample1 GG_OTU_2    1.0 5.0 5.0 1.0 0.625    k__2      p__     c__     o__     f__     g__     s__
 f3  Sample2 GG_OTU_2    1.0 1.0 1.0 1.0 0.125    k__2      p__     c__     o__     f__     g__     s__
 f3  Sample4 GG_OTU_2    1.0 2.0 2.0 1.0 0.25    k__2      p__     c__     o__     f__     g__     s__"""
+
+
+#Simple gene with only 1 pathway annotation
+example_metadata1 = {"KEGG_Description": ["cathepsin L [EC:3.4.22.15]"],\
+ "KEGG_Pathways": [["Cellular Processes", "Transport and Catabolism",\
+    "Phagosome"],["Unclassified"]]}
+#Complex annoation with phagosome
+example_metadata2 = {"KEGG_Description": ["cathepsin L [EC:3.4.22.15]"],\
+  "KEGG_Pathways":\
+    [["Human Diseases", "Immune System Diseases","Rheumatoid arthritis"],\
+     ["Metabolism", "Enzyme Families", "Peptidases"],
+     ["Organismal Systems", "Immune System",\
+       "Antigen processing and presentation"],\
+     ["Cellular Processes", "Transport and Catabolism", "Phagosome"],\
+     ["Genetic Information Processing", "Folding, Sorting and Degradation",\
+       "Chaperones and folding catalysts"],\
+     ["Cellular Processes", "Transport and Catabolism", "Lysosome"]]} 
+#Complex annotation without phagosome
+example_metadata3 = {"KEGG_Description": ["cathepsin L [EC:3.4.22.15]"],\
+  "KEGG_Pathways":\
+    [["Human Diseases", "Immune System Diseases","Rheumatoid arthritis"],\
+     ["Metabolism", "Enzyme Families", "Peptidases"],\
+     ["Organismal Systems", "Immune System",\
+       "Antigen processing and presentation"],\
+     ["Cellular Processes", "Transport and Catabolism","Unclassified"],\
+     ["Genetic Information Processing", "Folding, Sorting and Degradation",\
+       "Chaperones and folding catalysts"],\
+     ["Cellular Processes", "Transport and Catabolism", "Lysosome"]]} 
+
+
+
+
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This PR changes metagenome_contributions to specify a KEGG pathway name rather than a KO id.
Users can also specify a level of the hierarchy, since you might want e.g. Unknowns at a specific level.
The PR also includes some new test code for these functionalities. I didn't add any filtering by bacterial taxonomy, since that is sort of a separate change and I didn't want to mix updates.

In any case, check it out and let me know if you think any changes are needed.

