### PR TITLE
fixed call to Table.FilterObservations in metadata_contributions.py

### DIFF
--- a/picrust/metagenome_contributions.py
+++ b/picrust/metagenome_contributions.py
@@ -117,14 +117,7 @@ def partition_metagenome_contributions(otu_table,genome_table, limit_to_function
 
     if limit_to_functional_categories:
         fn_cat_filter = make_pathway_filter_fn(ok_values = frozenset(map(str,limit_to_functional_categories)),metadata_key=metadata_key)
-        genome_table = genome_table.filterObservations(fn_cat_filter)
-
-        if genome_table.is_empty():
-            raise ValueError("User filtering by functional categories (%s) removed all results from the genome table"%(str(limit_to_functional_categories)))
-
-    if limit_to_functional_categories:
-        fn_cat_filter = make_pathway_filter_fn(ok_values = frozenset(map(str,limit_to_functional_categories)),metadata_key=metadata_key)
-        genome_table = genome_table.filterObservations(fn_cat_filter)
+        genome_table = genome_table.filter(fn_cat_filter, axis='observation', inplace=False)
 
         if genome_table.is_empty():
             raise ValueError("User filtering by functional categories (%s) removed all results from the genome table"%(str(limit_to_functional_categories)))


### PR DESCRIPTION
I fixed a call to Table.filterObservations(), which is just filter() with an axis parameter in the newer BIOM API.

This was generating errors for users who wanted to filter the set of KOs showing up in metagenome contributions.py by functional categories.

Additionally, a few lines of code were duplicated, and I removed the duplicate.