### PR TITLE
added new galaxy link and gh-pages fixes

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -13,17 +13,29 @@ Using PICRUSt
 -------------
 If you're new to PICRUSt, you'll want to work through these documents in order:
 
-  #. :ref:`install`  **OR**  `Use online Galaxy version <http://huttenhower.sph.harvard.edu/galaxy/root?tool_id=PICRUSt_normalize>`_.
+  #. :ref:`install`  
+
+     **OR** 
+
+     Use online Galaxy version on either the `Langille Lab <http://galaxy.morganlangille.com/>`_ (v1.1.1) or `Huttenhower Lab <http://huttenhower.sph.harvard.edu/galaxy/root?tool_id=PICRUSt_normalize>`_ (v1.0.0) servers.
+
   #. :ref:`quickstart_guide`
+
   #. :ref:`metagenome_prediction_tutorial`
+
   #. :ref:`downstream_analysis_guide`
+
   #. :ref:`quality_control`
 
 More advanced users may be interested in the following (in no particular order):
   * :ref:`algorithm_description`
+
   * :ref:`genome_prediction_tutorial`
+
   * `Installing PICRUSt in Galaxy <https://github.com/picrust/picrust_galaxy>`_
+
   * :ref:`index_scripts`
+
   * :ref:`index_methods`
 
 

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -4,7 +4,7 @@
 Installing PICRUSt
 ==================
 
-.. note:: Most users will not need to install PICRUSt, but can instead use the `online Galaxy version <http://huttenhower.sph.harvard.edu/galaxy/root?tool_id=PICRUSt_normalize>`_.
+.. note:: Most users will not need to install PICRUSt, but can instead use the `online Galaxy version <http://galaxy.morganlangille.com/>`_.
 
 PICRUSt is written in python, and has been tested on Mac OS X and Linux systems. To install PICRUSt, first install all of the mandatory requirements, following the instructions on their respective websites. You should then download PICRUSt. You have the choice of downloading either the release version (recommended for most users) or the development version (recommended for users who need access to the latest features, and are willing to tolerate some instability in the code). Next, you will download the large precalculated PICRUSt files and place them in your picrust/data directory. Finally, you'll install PICRUSt. Each of these steps are detailed below.
 
@@ -15,23 +15,20 @@ Follow the install instructions found on the website of each of the dependencies
 
 **Mandatory**
 
-These dependencies are automatically installed with `python setup.py install`:
+These dependencies are automatically installed with `pip install .` below:
 
 * `python`_ (version 2.7)
 * `PyCogent`_ (version 1.5.3)
-* `biom`_ (version 2.1.5)
+* `biom`_ (version 2.1.6)
 
-Numpy and h5py have to be installed manually:
+h5py needs to be installed manually (numpy is also required, but it should be installed automatically with this package):
 
-* `numpy`_ (version 1.12.1)
 * `h5py`_ (version 2.7.0)
 
-You can install them with these commands::
-    
+You can install h5py with this command::
+	
         pip install h5py 
-
-        pip install numpy 
-    
+	    	
 **Rebuilding PICRUSt's precalculated 16S rRNA OR Genome Predictions (optional)**
 
 * `R`_ installed with `APE`_ library

--- a/doc/source/scripts/normalize_by_copy_number.rst
+++ b/doc/source/scripts/normalize_by_copy_number.rst
@@ -32,8 +32,6 @@
 		Precalculated input marker gene copy number predictions on per otu basis in biom format (can be gzipped).Note: using this option overrides --gg_version. [default: None]
 	`-`-metadata_identifer
 		Identifier for copy number entry as observation metadata [default: CopyNumber]
-	-f, `-`-input_format_classic
-		Input otu table (--input_otu_fp) is in classic Qiime format [default: False]
 	`-`-load_precalc_file_in_biom
 		Instead of loading the precalculated file in tab-delimited format (with otu ids as row ids and traits as columns) load the data in biom format (with otu as SampleIds and traits as ObservationIds) [default: False]
 
@@ -49,11 +47,6 @@ Normalize the OTU abundances for a given OTU table picked against the newest ver
 
 	normalize_by_copy_number.py -i closed_picked_otus.biom -o normalized_otus.biom
 
-Input tab-delimited OTU table:
-
-::
-
-	normalize_by_copy_number.py -f -i closed_picked_otus.tab -o normalized_otus.biom
 
 Change the version of Greengenes used for OTU picking:
 


### PR DESCRIPTION
Added link to new galaxy, specified biom 2.1.6, and removed -f option for normalize_by_copy_number.py.

Note that the galaxy at http://galaxy.morganlangille.com/ is the main one linked to now.

Couldn't reproduce error with biom 2.1.6 so I think it was some other issue in the environment I was working in so the instructions to install biom 2.1.5 specifically should be removed.

