### PR TITLE
Parallel script names

### DIFF
--- a/picrust/ancestral_state_reconstruction.py
+++ b/picrust/ancestral_state_reconstruction.py
@@ -66,11 +66,11 @@ def run_asr_in_parallel(tree, table, asr_method, parallel_method='sge',tmp_dir='
     asr_script_fp = join(get_picrust_project_dir(),'scripts','ancestral_state_reconstruction.py')
 
     if(parallel_method=='sge'):
-        cluster_jobs_fp=join(get_picrust_project_dir(),'scripts','start_parallel_jobs_sge.py')
+        cluster_jobs_fp=join(get_picrust_project_dir(),'scripts','start_parallel_picrust_jobs_sge.py')
     elif(parallel_method=='multithreaded'):
-        cluster_jobs_fp=join(get_picrust_project_dir(),'scripts','start_parallel_jobs.py')
+        cluster_jobs_fp=join(get_picrust_project_dir(),'scripts','start_parallel_picrust_jobs.py')
     elif(parallel_method=='torque'):
-        cluster_jobs_fp=join(get_picrust_project_dir(),'scripts','start_parallel_jobs_torque.py')
+        cluster_jobs_fp=join(get_picrust_project_dir(),'scripts','start_parallel_picrust_jobs_torque.py')
     else:
         raise RuntimeError
 


### PR DESCRIPTION
The scripts to run PICRUSt jobs in parallel were previously re-named due to a conflict issue. However, the old names were hard-coded in ancestral_state_reconstruction.py - I updated the script names there.