### PR TITLE
Genome evaluation edits

### DIFF
--- a/picrust/evaluate_test_datasets.py
+++ b/picrust/evaluate_test_datasets.py
@@ -27,7 +27,7 @@ def merge_by_column_union(old_table,new_table,new_field_modifier):
 
     new_table.update_ids(new_sample_ids)
 
-    merged_table =  old_table.merge(new_table,Sample='union',Observation='intersection')
+    merged_table =  old_table.merge(new_table,sample='union',observation='intersection')
     return merged_table
 
 def update_pooled_data(obs_table,exp_table,tags,pooled_observations,\

--- a/scripts/evaluate_test_datasets.py
+++ b/scripts/evaluate_test_datasets.py
@@ -134,7 +134,8 @@ def evaluate_test_dataset_dir(obs_dir_fp,exp_dir_fp,file_name_delimiter="--",\
 
             try:
               obs_table =\
-                load_table(join(obs_dir_fp,f),'U')
+                load_table(join(obs_dir_fp,f))
+              obs_table = obs_table.transpose()
             except ValueError:
                 print 'Failed, skipping...'
                 continue

--- a/scripts/run_genome_evaluations.py
+++ b/scripts/run_genome_evaluations.py
@@ -69,7 +69,7 @@ make_option('-w','--weighting_method',type='choice',\
             ', '.join(weighting_choices) + ' [default: %default]',\
             choices=weighting_choices,default='exponential'),\
 make_option('-n','--num_jobs',action='store',type='int',\
-            help='Number of jobs to be submitted (if --parallel). [default: %default]',\
+            help='Number of jobs to be submitted. [default: %default]',\
             default=100),\
 make_option('--tmp-dir',type="new_dirpath",help='location to store intermediate files [default: <output_dir>]'),\
 make_option('--force',action='store_true',default=False, help='run all jobs even if output files exist [default: %default]'),\

--- a/scripts/run_genome_evaluations.py
+++ b/scripts/run_genome_evaluations.py
@@ -91,7 +91,7 @@ def main():
     asr_method = opts.asr_method
     predict_traits_method = opts.prediction_method
     
-    if opts.num_jobs > 20 and parallel_method == 'multithreaded':
+    if opts.num_jobs > 80 and parallel_method == 'multithreaded':
         raise ValueError('You probably dont want to run multithreaded evaluations with a large num_jobs. Please adjust options num_jobs and or parallel_method')
         
     if opts.with_confidence and asr_method not in ['ace_ml','ace_reml']:


### PR DESCRIPTION
Edited description so that "--parallel" option isnt there anymore (since it seems to always be run in parallel unless N=1).

Also, changed syntax for reading in biom table which is no longer correct, but must have been in an older version. Also, changed observation and sample axes to lowercase, which also must have been due to a minor change in biom format syntax.

Lastly, I believe when this script was originally used that the observed table must have been in biom format (samples as columns and observations as rows), but it is now the opposite by default. I added in a line that transposes the input table and the rest of the commands seem to work.

@zaneveld would you mind taking a quick look at these minor changes?