### PR TITLE
added warning when CIs cannot be calculated

### DIFF
--- a/picrust/predict_traits.py
+++ b/picrust/predict_traits.py
@@ -844,6 +844,7 @@ def get_brownian_motion_param_from_confidence_intervals(tree,\
     """
     #variances = []  # holds arrays of variances across traits for each sequenced tip
     #distances = []  # holds a single distnace for each sequenced tip to its parent
+    variances = None
     tips_with_traits = 0
     for tip in tree.iterTips():
         if getattr(tip,trait_label,None) is not None:
@@ -889,6 +890,10 @@ def get_brownian_motion_param_from_confidence_intervals(tree,\
             break
     if tips_with_traits == 0:
         raise ValueError("No tips have trait values annotated under label:"+trait_label)
+
+    if not variances:
+	raise ValueError("Example variances could not be calculated for CIs. There may not be any cases of tip pairs where one has known and the other unknown trait values.")
+
     #now just average variances/d for all examples to get the brownian motion param
     #print "variances:", variances
     #print "distances:", distances


### PR DESCRIPTION
predict_traits.py needs at least one pair of sister tips where one has a known and the other an unknown trait value to calculate CIs. I added in a warning to clarify the error that occurs when the phylogeny does not have any such pairs and the user species CIs (-c).

See this thread for an example error: https://groups.google.com/forum/#!topic/picrust-users/PSR48-9_YQM
