### PR TITLE
changed check for missing variances

### DIFF
--- a/picrust/predict_traits.py
+++ b/picrust/predict_traits.py
@@ -891,7 +891,7 @@ def get_brownian_motion_param_from_confidence_intervals(tree,\
     if tips_with_traits == 0:
         raise ValueError("No tips have trait values annotated under label:"+trait_label)
 
-    if not variances:
+    if variances == None:
 	raise ValueError("Example variances could not be calculated for CIs. There may not be any cases of tip pairs where one has known and the other unknown trait values.")
 
     #now just average variances/d for all examples to get the brownian motion param


### PR DESCRIPTION
Converting the numpy array ```variances``` to a boolean variable caused this error with a travis test: 

```ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()```

This may depend on the version of numpy used since I didn't get this locally.

The new syntax should get around this error by just checking to see if ```variances``` is equal to ```None``` (which is how it is initialized).