### PR TITLE
Rename ace -> wrap_asr (and function) in tests

### DIFF
--- a/tests/test_ace.py
+++ b/tests/test_ace.py
@@ -13,7 +13,7 @@ __status__ = "Development"
  
 
 from cogent.util.unit_test import TestCase, main
-from picrust.ace import ace_for_picrust
+from picrust.wrap_asr import ape_ace_wrapper
 from cogent.app.util import get_tmp_filename
 from cogent.util.misc import remove_files
 from cogent import LoadTable
@@ -60,10 +60,10 @@ class AceTests(TestCase):
         remove_files(self.files_to_remove)
                        
 
-    def test_ace_for_picrust_ml(self):
-        """ test_ace_for_picrust with method 'ML' functions as expected with valid input
+    def test_ape_ace_wrapper_ml(self):
+        """ test_ape_ace_wrapper with method 'ML' functions as expected with valid input
         """
-        actual,actual_ci= ace_for_picrust(self.in_tree1_fp, self.in_trait1_fp, method="ML")
+        actual,actual_ci= ape_ace_wrapper(self.in_tree1_fp, self.in_trait1_fp, method="ML")
         expected=Table(['nodes','trait1','trait2'],[['14','2.9737','2.5436'],['12','2.3701','2.7056'],['11','0.8370','2.9706'],['10','4.4826','2.1388']])
         self.assertEqual(actual.tostring(),expected.tostring())
         expected_ci=Table(['nodes','trait1','trait2'],\
@@ -78,10 +78,10 @@ class AceTests(TestCase):
 
    
 
-    def test_ace_for_picrust_pic(self):
-        """ test_ace_for_picrust with method 'pic' functions as expected with valid input
+    def test_ape_ace_wrapper_pic(self):
+        """ test_ape_ace_wrapper with method 'pic' functions as expected with valid input
         """
-        actual,actual_ci= ace_for_picrust(self.in_tree1_fp,self.in_trait1_fp, method="pic")
+        actual,actual_ci= ape_ace_wrapper(self.in_tree1_fp,self.in_trait1_fp, method="pic")
         expected=Table(['nodes','trait1','trait2'],[['14','2.9737','2.5436'],['12','1.2727','3'],['11','0.6667','3'],['10','5','2']])
         self.assertEqual(actual.tostring(),expected.tostring())
         expected_ci=Table(['nodes','trait1','trait2'],\
@@ -93,17 +93,17 @@ class AceTests(TestCase):
         self.assertEqual(actual_ci.tostring(),expected_ci.tostring())
 
 
-    def test_ace_for_picrust_pic_single_trait(self):
-        """ test_ace_for_picrust with method 'pic' functions as expected with single column trait table
+    def test_ape_ace_wrapper_pic_single_trait(self):
+        """ test_ape_ace_wrapper with method 'pic' functions as expected with single column trait table
         """
-        actual,ci= ace_for_picrust(self.in_tree1_fp,self.in_trait2_fp, method="pic")
+        actual,ci= ape_ace_wrapper(self.in_tree1_fp,self.in_trait2_fp, method="pic")
         expected=Table(['nodes','trait1'],[['14','2.9737'],['12','1.2727'],['11','0.6667'],['10','5']])
         self.assertEqual(actual.tostring(),expected.tostring())
 
-    def test_ace_for_picrust_pic_with_funky_tip_labels(self):
-        """ test_ace_for_picrust for a tree with underscores in tip labels
+    def test_ape_ace_wrapper_pic_with_funky_tip_labels(self):
+        """ test_ape_ace_wrapper for a tree with underscores in tip labels
         """
-        actual,ci= ace_for_picrust(self.in_tree2_fp,self.in_trait3_fp, method="pic")
+        actual,ci= ape_ace_wrapper(self.in_tree2_fp,self.in_trait3_fp, method="pic")
         expected=Table(['nodes','trait1','trait2'],[['14','2.9737','2.5436'],['12','1.2727','3'],['11','0.6667','3'],['10','5','2']])
         self.assertEqual(actual.tostring(),expected.tostring())
         


### PR DESCRIPTION
Fixes the broken ace wrapper tests in `test_ace.py`.