### PR TITLE
removed numpy check statements from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,16 +13,6 @@ __maintainer__ = "Greg Caporaso"
 __email__ = "gregcaporaso@gmail.com"
 __status__ = "Development"
 
-
-try:
-    import numpy
-except ImportError:
-    raise ImportError("numpy cannot be found. Can't continue. Please install "
-                      "the numpy package (see www.numpy.org)")
-else:
-    numpy  # avoid unused variable error
-
-
 long_description = ("PICRUSt: Phylogenetic Investigation of Communities by "
                     "Reconstruction of Unobserved States\n\n"
                     "Predictive functional profiling of microbial communities "


### PR DESCRIPTION
Removed lines in ```setup.py``` that stopped script if numpy was not installed - I believe this was once required when running setuptools, but not longer seems to be necessary (it successfully installed without these lines in a conda environment without numpy installed to begin with). 