### PR TITLE
Fix tree labels

### DIFF
--- a/picrust/support_files/R/ace.R
+++ b/picrust/support_files/R/ace.R
@@ -5,23 +5,14 @@ library(ape)
 Args <- commandArgs(TRUE)
 
 #load in the tree
-tree<-read.tree(Args[1])
+tree <- read.tree(Args[1])
 
 #load in the trait table
-data<-read.delim(Args[2],check.names=FALSE,row.names=1)
+data <- read.delim(Args[2], check.names=FALSE, row.names=1)
 
-
-asr_method=Args[3]
-count_out_file=Args[4]
-ci_out_file=Args[5]
-
-#If tips in tree contain '_' then read.tree() places single quotes around these tip labels.
-#This then causes sorting errors below since the rownames are different between the trait table and the tree.
-#Fix this by putting quotes around any labels in the trait table that have a '_'.
-for(i in grep("_",rownames(data))){
- rownames(data)[i]<-paste("'",rownames(data)[i],"'",sep="")
-}
-
+asr_method = Args[3]
+count_out_file = Args[4]
+ci_out_file = Args[5]
 
 #order the trait table to match the tree tip labels
 #The option "drop=FALSE" means that a dataframe will be returned even if there 
@@ -29,61 +20,61 @@ for(i in grep("_",rownames(data))){
 data_ordered <- data[tree$tip.label , , drop=FALSE]
 
 #do the actual ace reconsructions
-reconstructions<-apply(data_ordered,2,ace,tree, type="continuous",method=asr_method)
+reconstructions <- apply(data_ordered, 2, ace, tree, type="continuous", method=asr_method)
 
 #pull out only the ace node predictions
-just_ace<-lapply(1:length(reconstructions),function(x) reconstructions[[x]]$ace)
-names(just_ace)<-names(reconstructions)
+just_ace <- lapply(1:length(reconstructions),function(x) reconstructions[[x]]$ace)
+names(just_ace) <- names(reconstructions)
 
 #reformat the list into a matrix
-just_ace_matrix<-do.call(cbind,just_ace)
+just_ace_matrix <- do.call(cbind,just_ace)
 
 #relabel the node names (ones created internally by ape) with the actual node labels in the tree
-just_ace_matrix<-cbind(tree$node.label,just_ace_matrix)
+just_ace_matrix <- cbind(tree$node.label,just_ace_matrix)
 
 #give a simple header label for the internal nodes
-colnames(just_ace_matrix)[1]<-'nodes'
+colnames(just_ace_matrix)[1] <- 'nodes'
 
 #Convert to a data frame
-out_matrix<-data.frame(just_ace_matrix,check.names=FALSE)
+out_matrix <- data.frame(just_ace_matrix, check.names=FALSE)
 
 #write to file
-write.table(out_matrix,file=count_out_file,row.names=FALSE,quote=FALSE, sep="\t")
+write.table(out_matrix, file=count_out_file, row.names=FALSE, quote=FALSE, sep="\t")
 
 
 #extract 95% CI info
-ci<-lapply(1:length(reconstructions),function(x) paste(round(reconstructions[[x]]$CI95[,1],digits=4),round(reconstructions[[x]]$CI95[,2],digits=4),sep="|"))
-names(ci)<-names(reconstructions)                                                                                
-ci_matrix<-do.call(cbind,ci)
-ci_matrix<-cbind(tree$node.label,ci_matrix)
+ci <- lapply(1:length(reconstructions),function(x) paste(round(reconstructions[[x]]$CI95[,1], digits=4), round(reconstructions[[x]]$CI95[,2], digits=4), sep="|"))
+names(ci) <- names(reconstructions)                                                                                
+ci_matrix <- do.call(cbind, ci)
+ci_matrix <- cbind(tree$node.label, ci_matrix)
 
 if(asr_method=="ML" || asr_method=="REML"){
   #extract information about brownian motion parameter
-  sigma<-lapply(1:length(reconstructions),function(x) paste(round(reconstructions[[x]]$sigma2[1],digits=4),round(reconstructions[[x]]$sigma2[2],digits=4),sep="|"))
-  names(sigma)<-names(reconstructions)                                                                                
-  sigma_matrix<-do.call(cbind,sigma)
-  sigma_matrix<-cbind(c('sigma'),sigma_matrix)
+  sigma <- lapply(1:length(reconstructions),function(x) paste(round(reconstructions[[x]]$sigma2[1], digits=4), round(reconstructions[[x]]$sigma2[2], digits=4), sep="|"))
+  names(sigma) <- names(reconstructions)                                                                                
+  sigma_matrix <- do.call(cbind, sigma)
+  sigma_matrix <- cbind(c('sigma'), sigma_matrix)
   
   #add it to the ci matrix
-  ci_matrix<-rbind(ci_matrix,sigma_matrix)
+  ci_matrix <- rbind(ci_matrix, sigma_matrix)
 
   #get loglik value
   if(asr_method=="ML"){
-    loglik<-lapply(1:length(reconstructions),function(x) round(reconstructions[[x]]$loglik,digits=4))                                                                                                                           
+    loglik <- lapply(1:length(reconstructions),function(x) round(reconstructions[[x]]$loglik, digits=4))                                                                                                                           
   }else{
-    loglik<-lapply(1:length(reconstructions),function(x) round(reconstructions[[x]]$resloglik,digits=4))                                                                                                                                                                                        
+    loglik <- lapply(1:length(reconstructions),function(x) round(reconstructions[[x]]$resloglik, digits=4))                                                                                                                                                                                        
   }
 
-  names(loglik)<-names(reconstructions)
-  loglik_matrix<-do.call(cbind,loglik)
-  loglik_matrix<-cbind(c('loglik'),loglik_matrix)
-  ci_matrix<-rbind(ci_matrix,loglik_matrix)
+  names(loglik) <- names(reconstructions)
+  loglik_matrix <- do.call(cbind, loglik)
+  loglik_matrix <- cbind(c('loglik'), loglik_matrix)
+  ci_matrix <- rbind(ci_matrix, loglik_matrix)
 
 }
   
 #just set the column name for the row names to someting arbtrary like 'nodes'
-colnames(ci_matrix)[1]<-'nodes'
+colnames(ci_matrix)[1] <- 'nodes'
 
 #output the data to file
-out_matrix<-data.frame(ci_matrix,check.names=FALSE)                                                                                                                 
-write.table(out_matrix,file=ci_out_file,row.names=FALSE,quote=FALSE, sep="\t")
+out_matrix <- data.frame(ci_matrix, check.names=FALSE)                                                                                                                 
+write.table(out_matrix, file=ci_out_file, row.names=FALSE, quote=FALSE, sep="\t")

--- a/picrust_test_data/ancestral_state_reconstruction/asr_ci.tab
+++ b/picrust_test_data/ancestral_state_reconstruction/asr_ci.tab
@@ -1,3 +1,3 @@
 nodes	trait1	trait2
 root	4e-04|1.9996	0.3084|2.3075
-'internal_node_2'	-0.96|2.96	-1.76|2.16
+internal_node_2	-0.96|2.96	-1.76|2.16

--- a/picrust_test_data/ancestral_state_reconstruction/asr_counts.tab
+++ b/picrust_test_data/ancestral_state_reconstruction/asr_counts.tab
@@ -1,3 +1,3 @@
 nodes	trait1	trait2
-root	1	1.30795847751
-'internal_node_2'	1	0.2
+root	1	1.30795847750865
+internal_node_2	1	0.2

--- a/picrust_test_data/ancestral_state_reconstruction/pruned_tree.newick
+++ b/picrust_test_data/ancestral_state_reconstruction/pruned_tree.newick
@@ -1,1 +1,1 @@
-(A:0.1,(B:0.2,C:0.8)'internal_node_2':0.0001)root;
+(A:0.1,(B_extra:0.2,C:0.8)internal_node_2:0.0001)root;

--- a/picrust_test_data/ancestral_state_reconstruction/trait_table.tab
+++ b/picrust_test_data/ancestral_state_reconstruction/trait_table.tab
@@ -1,4 +1,4 @@
 taxa	trait1	trait2
 A	1	2
-B	1	0
+B_extra	1	0
 C	1	1

--- a/picrust_test_data/predict_traits/asr_ci.tab
+++ b/picrust_test_data/predict_traits/asr_ci.tab
@@ -1,3 +1,3 @@
 nodes	trait1	trait2
 root	4e-04|1.9996	0.3084|2.3075
-'internal_node_2'	-0.96|2.96	-1.76|2.16
+internal_node_2	-0.96|2.96	-1.76|2.16

--- a/picrust_test_data/predict_traits/asr_counts.tab
+++ b/picrust_test_data/predict_traits/asr_counts.tab
@@ -1,3 +1,3 @@
 nodes	trait1	trait2
-root	1	1.30795847751
-'internal_node_2'	1	0.2
+root	1	1.30795847750865
+internal_node_2	1	0.2


### PR DESCRIPTION
Removed code from ```ace.R``` that would add single-quotes around tip labels if they contained an underscore. This was originally done because the ape R package used to do this when reading in trees apparently, but this is no longer the case and causes issues in cases where tips contain underscores since there is a mismatch between the labels in the R objects containing the trait and tip labels.